### PR TITLE
Improve CdB Eventos plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# cdb-eventos
+# CdB Eventos
+
+Plugin de WordPress para gestionar eventos e inscripciones.
+
+## Instalación
+
+1. Copia la carpeta del plugin en `wp-content/plugins`.
+2. Activa **CdB Eventos** desde el panel de administración.
+
+## Shortcodes disponibles
+
+- `[cdb_eventos_lista]` &mdash; muestra un listado de próximos eventos.
+- `[cdb_evento_inscripcion]` &mdash; formulario de inscripción en la página de un evento.
+- `[cdb_eventos_inscritos]` &mdash; lista los eventos en los que el usuario está inscrito.
+
+## Personalización
+
+El plugin carga el archivo `assets/cdb-eventos.css`. Puedes editarlo para modificar el estilo de los listados y formularios.

--- a/assets/cdb-eventos.css
+++ b/assets/cdb-eventos.css
@@ -1,0 +1,11 @@
+/* Basic styles for CdB Eventos plugin */
+.cdb-eventos-lista {
+    margin: 0;
+    padding: 0;
+}
+.cdb-evento-item {
+    margin-bottom: 2rem;
+}
+.cdb-evento-inscrito-item {
+    margin-bottom: 2rem;
+}

--- a/cdb-eventos.php
+++ b/cdb-eventos.php
@@ -18,6 +18,22 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/inscripciones.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/visibilidad.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/usuario-suscripciones.php';
 
+/**
+ * Cargar el dominio de traducción para el plugin.
+ */
+function cdb_eventos_load_textdomain() {
+    load_plugin_textdomain( 'cdb-eventos', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+}
+add_action( 'plugins_loaded', 'cdb_eventos_load_textdomain' );
+
+/**
+ * Encolar los estilos del plugin.
+ */
+function cdb_eventos_enqueue_assets() {
+    wp_enqueue_style( 'cdb-eventos', plugins_url( 'assets/cdb-eventos.css', __FILE__ ), array(), '1.0' );
+}
+add_action( 'wp_enqueue_scripts', 'cdb_eventos_enqueue_assets' );
+
 
 // Clase principal del plugin
 class CdB_Eventos {

--- a/includes/inscripciones.php
+++ b/includes/inscripciones.php
@@ -12,8 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 function cdb_evento_inscripcion_shortcode( $atts ) {
     global $post;
 
-    // Asegurarse de que estamos en un post del tipo 'evento'
-    if ( 'evento' !== $post->post_type ) {
+    // Asegurarse de que estamos en un post de tipo 'evento'
+    if ( ! ( $post instanceof WP_Post ) || 'evento' !== $post->post_type ) {
         return '';
     }
 
@@ -29,7 +29,7 @@ function cdb_evento_inscripcion_shortcode( $atts ) {
     }
 
     // Verificar si el usuario ya está inscrito.
-    if ( in_array( $user_id, $inscripciones ) ) {
+    if ( in_array( $user_id, $inscripciones, true ) ) {
         return '<p>Ya estás inscrito en este evento.</p>';
     }
 


### PR DESCRIPTION
## Summary
- load translation domain on `plugins_loaded`
- enqueue a public stylesheet
- validate `$post` before processing shortcode
- use strict comparison when verifying user subscription
- document available shortcodes and customization options

## Testing
- `php -l cdb-eventos.php`
- `php -l includes/inscripciones.php`
- `php -l includes/usuario-suscripciones.php`
- `php -l includes/visibilidad.php`


------
https://chatgpt.com/codex/tasks/task_e_6885656d4df083279b5481eb83cabeaf