### PR TITLE
Add configurable messages system

### DIFF
--- a/assets/css/config-mensajes.css
+++ b/assets/css/config-mensajes.css
@@ -1,0 +1,28 @@
+.cdb-eventos-mensaje {
+    padding: 10px 15px;
+    margin: 15px 0;
+    border-left: 4px solid transparent;
+}
+.cdb-eventos-mensaje.cdb-eventos-info {
+    background: #e5f5fa;
+    border-color: #46bfe2;
+    color: #0a4b78;
+}
+.cdb-eventos-mensaje.cdb-eventos-exito {
+    background: #e7f8ec;
+    border-color: #46b450;
+    color: #1e5220;
+}
+.cdb-eventos-mensaje.cdb-eventos-aviso {
+    background: #fff8e5;
+    border-color: #ffb900;
+    color: #604400;
+}
+.cdb-eventos-mensaje.cdb-eventos-error {
+    background: #fbeaea;
+    border-color: #dc3232;
+    color: #760000;
+}
+#cdb-eventos-tipos .form-table td input[type="text"] {
+    width: 100%;
+}

--- a/assets/js/config-mensajes.js
+++ b/assets/js/config-mensajes.js
@@ -1,0 +1,21 @@
+jQuery(document).ready(function($){
+    if (typeof $.fn.wpColorPicker !== 'undefined') {
+        $('.cdb-color-field').wpColorPicker();
+    }
+    $('#cdb-eventos-add-tipo').on('click', function(e){
+        e.preventDefault();
+        var table = $('#cdb-eventos-tipos').find('tbody');
+        var index = table.find('tr').length;
+        var row = '<tr>'+
+            '<td><input type="text" name="tipos[slug][]" value="" /></td>'+
+            '<td><input type="text" name="tipos[nombre][]" value="" /></td>'+
+            '<td><input type="text" name="tipos[clase][]" value="" /></td>'+
+            '<td><input type="text" class="cdb-color-field" name="tipos[color][]" value="" /></td>'+
+            '<td><input type="text" class="cdb-color-field" name="tipos[color_texto][]" value="" /></td>'+
+            '</tr>';
+        table.append(row);
+        if (typeof $.fn.wpColorPicker !== 'undefined') {
+            table.find('.cdb-color-field').wpColorPicker();
+        }
+    });
+});

--- a/assets/js/mensajes.js
+++ b/assets/js/mensajes.js
@@ -1,0 +1,3 @@
+(function(){
+    window.cdb_eventos_mensajes = window.cdb_eventos_mensajes || {};
+})();

--- a/cdb-eventos.php
+++ b/cdb-eventos.php
@@ -12,11 +12,21 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+if ( ! defined( 'CDB_EVENTOS_PATH' ) ) {
+    define( 'CDB_EVENTOS_PATH', plugin_dir_path( __FILE__ ) );
+}
+if ( ! defined( 'CDB_EVENTOS_URL' ) ) {
+    define( 'CDB_EVENTOS_URL', plugin_dir_url( __FILE__ ) );
+}
+
 // Incluir archivos de funcionalidades
-require_once plugin_dir_path( __FILE__ ) . 'includes/meta-boxes.php';
-require_once plugin_dir_path( __FILE__ ) . 'includes/inscripciones.php';
-require_once plugin_dir_path( __FILE__ ) . 'includes/visibilidad.php';
-require_once plugin_dir_path( __FILE__ ) . 'includes/usuario-suscripciones.php';
+require_once CDB_EVENTOS_PATH . 'includes/meta-boxes.php';
+require_once CDB_EVENTOS_PATH . 'includes/inscripciones.php';
+require_once CDB_EVENTOS_PATH . 'includes/visibilidad.php';
+require_once CDB_EVENTOS_PATH . 'includes/usuario-suscripciones.php';
+require_once CDB_EVENTOS_PATH . 'includes/messages.php';
+require_once CDB_EVENTOS_PATH . 'includes/config-mensajes.php';
+require_once CDB_EVENTOS_PATH . 'includes/scripts.php';
 
 /**
  * Cargar el dominio de traducción para el plugin.
@@ -25,15 +35,6 @@ function cdb_eventos_load_textdomain() {
     load_plugin_textdomain( 'cdb-eventos', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
 }
 add_action( 'plugins_loaded', 'cdb_eventos_load_textdomain' );
-
-/**
- * Encolar los estilos del plugin.
- */
-function cdb_eventos_enqueue_assets() {
-    wp_enqueue_style( 'cdb-eventos', plugins_url( 'assets/cdb-eventos.css', __FILE__ ), array(), '1.0' );
-}
-add_action( 'wp_enqueue_scripts', 'cdb_eventos_enqueue_assets' );
-
 
 // Clase principal del plugin
 class CdB_Eventos {

--- a/includes/config-mensajes.php
+++ b/includes/config-mensajes.php
@@ -1,0 +1,132 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+function cdb_eventos_mensajes_admin_menu() {
+    $parent_slug = 'edit.php?post_type=evento';
+    add_submenu_page(
+        $parent_slug,
+        __( 'Configuración de Mensajes y Avisos', 'cdb-eventos' ),
+        __( 'Mensajes', 'cdb-eventos' ),
+        'manage_options',
+        'cdb_eventos_mensajes',
+        'cdb_eventos_mensajes_admin_page'
+    );
+}
+add_action( 'admin_menu', 'cdb_eventos_mensajes_admin_menu' );
+
+function cdb_eventos_mensajes_admin_enqueue( $hook ) {
+    if ( 'evento_page_cdb_eventos_mensajes' !== $hook ) {
+        return;
+    }
+    wp_enqueue_style( 'wp-color-picker' );
+    wp_enqueue_style( 'cdb-eventos-config-mensajes', CDB_EVENTOS_URL . 'assets/css/config-mensajes.css', array(), '1.0' );
+    wp_enqueue_script( 'wp-color-picker' );
+    wp_enqueue_script( 'cdb-eventos-config-mensajes', CDB_EVENTOS_URL . 'assets/js/config-mensajes.js', array( 'jquery', 'wp-color-picker' ), '1.0', true );
+}
+add_action( 'admin_enqueue_scripts', 'cdb_eventos_mensajes_admin_enqueue' );
+
+function cdb_eventos_mensajes_admin_page() {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        return;
+    }
+
+    if ( isset( $_POST['cdb_eventos_mensajes_nonce'] ) && wp_verify_nonce( $_POST['cdb_eventos_mensajes_nonce'], 'cdb_eventos_guardar_mensajes' ) ) {
+        $mensajes = cdb_eventos_get_mensajes_default();
+        if ( isset( $_POST['mensaje'] ) && is_array( $_POST['mensaje'] ) ) {
+            foreach ( $mensajes as $clave => $msg ) {
+                if ( isset( $_POST['mensaje'][ $clave ] ) ) {
+                    $datos = $_POST['mensaje'][ $clave ];
+                    $mensajes[ $clave ]['texto']     = sanitize_text_field( $datos['texto'] );
+                    $mensajes[ $clave ]['secundario']= sanitize_text_field( $datos['secundario'] );
+                    $mensajes[ $clave ]['tipo']      = sanitize_key( $datos['tipo'] );
+                    $mensajes[ $clave ]['mostrar']   = isset( $datos['mostrar'] ) ? 1 : 0;
+                }
+            }
+        }
+        update_option( 'cdb_eventos_mensajes', $mensajes );
+
+        $tipos = array();
+        if ( isset( $_POST['tipos'] ) && is_array( $_POST['tipos'] ) ) {
+            $slugs  = isset( $_POST['tipos']['slug'] ) ? (array) $_POST['tipos']['slug'] : array();
+            $nombres= isset( $_POST['tipos']['nombre'] ) ? (array) $_POST['tipos']['nombre'] : array();
+            $clases = isset( $_POST['tipos']['clase'] ) ? (array) $_POST['tipos']['clase'] : array();
+            $colores= isset( $_POST['tipos']['color'] ) ? (array) $_POST['tipos']['color'] : array();
+            $ctexto = isset( $_POST['tipos']['color_texto'] ) ? (array) $_POST['tipos']['color_texto'] : array();
+            $count  = max( count( $slugs ), count( $nombres ) );
+            for ( $i = 0; $i < $count; $i++ ) {
+                $slug = sanitize_key( $slugs[ $i ] );
+                if ( empty( $slug ) ) {
+                    continue;
+                }
+                $tipos[ $slug ] = array(
+                    'nombre'      => sanitize_text_field( $nombres[ $i ] ),
+                    'clase'       => sanitize_html_class( $clases[ $i ] ),
+                    'color'       => sanitize_hex_color( $colores[ $i ] ),
+                    'color_texto' => sanitize_hex_color( $ctexto[ $i ] ),
+                );
+            }
+        }
+        update_option( 'cdb_eventos_tipos_color', $tipos );
+        echo '<div class="updated"><p>' . esc_html__( 'Ajustes guardados.', 'cdb-eventos' ) . '</p></div>';
+    }
+
+    $mensajes = cdb_eventos_get_mensajes();
+    $tipos    = cdb_eventos_get_tipos_color();
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'Configuración de Mensajes y Avisos', 'cdb-eventos' ); ?></h1>
+        <form method="post">
+            <?php wp_nonce_field( 'cdb_eventos_guardar_mensajes', 'cdb_eventos_mensajes_nonce' ); ?>
+            <h2><?php esc_html_e( 'Mensajes', 'cdb-eventos' ); ?></h2>
+            <table class="form-table">
+                <tbody>
+                <?php foreach ( $mensajes as $clave => $mensaje ) : ?>
+                    <tr>
+                        <th scope="row"><label for="mensaje-<?php echo esc_attr( $clave ); ?>"><?php echo esc_html( $clave ); ?></label></th>
+                        <td>
+                            <input type="text" id="mensaje-<?php echo esc_attr( $clave ); ?>" name="mensaje[<?php echo esc_attr( $clave ); ?>][texto]" value="<?php echo esc_attr( $mensaje['texto'] ); ?>" class="regular-text" />
+                            <input type="text" name="mensaje[<?php echo esc_attr( $clave ); ?>][secundario]" value="<?php echo esc_attr( $mensaje['secundario'] ); ?>" class="regular-text" placeholder="<?php esc_attr_e( 'Texto secundario', 'cdb-eventos' ); ?>" />
+                            <select name="mensaje[<?php echo esc_attr( $clave ); ?>][tipo]">
+                                <?php foreach ( $tipos as $slug => $tipo ) : ?>
+                                    <option value="<?php echo esc_attr( $slug ); ?>" <?php selected( $mensaje['tipo'], $slug ); ?>><?php echo esc_html( $tipo['nombre'] ); ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                            <label><input type="checkbox" name="mensaje[<?php echo esc_attr( $clave ); ?>][mostrar]" value="1" <?php checked( $mensaje['mostrar'], 1 ); ?> /> <?php esc_html_e( 'Mostrar', 'cdb-eventos' ); ?></label>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+
+            <h2><?php esc_html_e( 'Tipos de aviso', 'cdb-eventos' ); ?></h2>
+            <table class="form-table" id="cdb-eventos-tipos">
+                <thead>
+                    <tr>
+                        <th><?php esc_html_e( 'Slug', 'cdb-eventos' ); ?></th>
+                        <th><?php esc_html_e( 'Nombre', 'cdb-eventos' ); ?></th>
+                        <th><?php esc_html_e( 'Clase', 'cdb-eventos' ); ?></th>
+                        <th><?php esc_html_e( 'Color', 'cdb-eventos' ); ?></th>
+                        <th><?php esc_html_e( 'Color del texto', 'cdb-eventos' ); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ( $tipos as $slug => $tipo ) : ?>
+                    <tr>
+                        <td><input type="text" name="tipos[slug][]" value="<?php echo esc_attr( $slug ); ?>" /></td>
+                        <td><input type="text" name="tipos[nombre][]" value="<?php echo esc_attr( $tipo['nombre'] ); ?>" /></td>
+                        <td><input type="text" name="tipos[clase][]" value="<?php echo esc_attr( $tipo['clase'] ); ?>" /></td>
+                        <td><input type="text" class="cdb-color-field" name="tipos[color][]" value="<?php echo esc_attr( $tipo['color'] ); ?>" /></td>
+                        <td><input type="text" class="cdb-color-field" name="tipos[color_texto][]" value="<?php echo esc_attr( $tipo['color_texto'] ); ?>" /></td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+            <p><button id="cdb-eventos-add-tipo" class="button"><?php esc_html_e( 'Añadir tipo', 'cdb-eventos' ); ?></button></p>
+
+            <?php submit_button( __( 'Guardar cambios', 'cdb-eventos' ) ); ?>
+        </form>
+    </div>
+    <?php
+}

--- a/includes/inscripciones.php
+++ b/includes/inscripciones.php
@@ -19,7 +19,7 @@ function cdb_evento_inscripcion_shortcode( $atts ) {
 
     // Verificar si el usuario está logueado.
     if ( ! is_user_logged_in() ) {
-        return '<p>Debes iniciar sesión para inscribirte en este evento.</p>';
+        return cdb_eventos_get_mensaje( 'login_requerido' );
     }
 
     $user_id = get_current_user_id();
@@ -30,7 +30,7 @@ function cdb_evento_inscripcion_shortcode( $atts ) {
 
     // Verificar si el usuario ya está inscrito.
     if ( in_array( $user_id, $inscripciones, true ) ) {
-        return '<p>Ya estás inscrito en este evento.</p>';
+        return cdb_eventos_get_mensaje( 'ya_inscrito' );
     }
 
     // Procesar la inscripción al recibir el formulario.
@@ -40,7 +40,7 @@ function cdb_evento_inscripcion_shortcode( $atts ) {
         // Agregar el ID del usuario a la lista de inscripciones.
         $inscripciones[] = $user_id;
         update_post_meta( $post->ID, '_cdb_eventos_inscripciones', $inscripciones );
-        return '<p>¡Te has inscrito correctamente en el evento!</p>';
+        return cdb_eventos_get_mensaje( 'inscripcion_ok' );
     }
 
     // Mostrar el formulario de inscripción.
@@ -78,7 +78,7 @@ add_action( 'add_meta_boxes', 'cdb_eventos_inscripciones_meta_box' );
 function cdb_eventos_inscripciones_meta_box_callback( $post ) {
     $inscripciones = get_post_meta( $post->ID, '_cdb_eventos_inscripciones', true );
     if ( ! is_array( $inscripciones ) || empty( $inscripciones ) ) {
-        echo '<p>No hay inscripciones para este evento.</p>';
+        echo '<p>' . esc_html( cdb_eventos_get_mensaje_text( 'sin_inscripciones' ) ) . '</p>';
         return;
     }
     echo '<ul>';

--- a/includes/messages.php
+++ b/includes/messages.php
@@ -1,0 +1,122 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+function cdb_eventos_get_mensajes_default() {
+    return array(
+        'login_requerido' => array(
+            'texto'     => __( 'Debes iniciar sesión para inscribirte en este evento.', 'cdb-eventos' ),
+            'secundario'=> '',
+            'tipo'      => 'aviso',
+            'mostrar'   => true,
+        ),
+        'ya_inscrito' => array(
+            'texto'     => __( 'Ya estás inscrito en este evento.', 'cdb-eventos' ),
+            'secundario'=> '',
+            'tipo'      => 'info',
+            'mostrar'   => true,
+        ),
+        'inscripcion_ok' => array(
+            'texto'     => __( '¡Te has inscrito correctamente en el evento!', 'cdb-eventos' ),
+            'secundario'=> '',
+            'tipo'      => 'exito',
+            'mostrar'   => true,
+        ),
+        'error_generico' => array(
+            'texto'     => __( 'Ha ocurrido un error. Por favor, inténtalo de nuevo más tarde.', 'cdb-eventos' ),
+            'secundario'=> '',
+            'tipo'      => 'error',
+            'mostrar'   => true,
+        ),
+        'sin_eventos' => array(
+            'texto'     => __( 'No hay eventos disponibles.', 'cdb-eventos' ),
+            'secundario'=> '',
+            'tipo'      => 'info',
+            'mostrar'   => true,
+        ),
+        'evento_finalizado' => array(
+            'texto'     => __( 'El evento ya ha finalizado.', 'cdb-eventos' ),
+            'secundario'=> '',
+            'tipo'      => 'aviso',
+            'mostrar'   => true,
+        ),
+        'sin_inscripciones' => array(
+            'texto'     => __( 'No hay inscripciones para este evento.', 'cdb-eventos' ),
+            'secundario'=> '',
+            'tipo'      => 'info',
+            'mostrar'   => true,
+        ),
+    );
+}
+
+function cdb_eventos_get_mensajes() {
+    $defaults = cdb_eventos_get_mensajes_default();
+    $saved    = get_option( 'cdb_eventos_mensajes', array() );
+    return wp_parse_args( $saved, $defaults );
+}
+
+function cdb_eventos_get_tipos_color_default() {
+    return array(
+        'info' => array(
+            'nombre'      => __( 'Información', 'cdb-eventos' ),
+            'clase'       => 'info',
+            'color'       => '#46bfe2',
+            'color_texto' => '#0a4b78',
+        ),
+        'exito' => array(
+            'nombre'      => __( 'Éxito', 'cdb-eventos' ),
+            'clase'       => 'exito',
+            'color'       => '#46b450',
+            'color_texto' => '#1e5220',
+        ),
+        'aviso' => array(
+            'nombre'      => __( 'Aviso', 'cdb-eventos' ),
+            'clase'       => 'aviso',
+            'color'       => '#ffb900',
+            'color_texto' => '#604400',
+        ),
+        'error' => array(
+            'nombre'      => __( 'Error', 'cdb-eventos' ),
+            'clase'       => 'error',
+            'color'       => '#dc3232',
+            'color_texto' => '#760000',
+        ),
+    );
+}
+
+function cdb_eventos_get_tipos_color() {
+    $defaults = cdb_eventos_get_tipos_color_default();
+    $saved    = get_option( 'cdb_eventos_tipos_color', array() );
+    return wp_parse_args( $saved, $defaults );
+}
+
+function cdb_eventos_get_mensaje_text( $clave ) {
+    $mensajes = cdb_eventos_get_mensajes();
+    return isset( $mensajes[ $clave ]['texto'] ) ? $mensajes[ $clave ]['texto'] : '';
+}
+
+function cdb_eventos_get_mensaje( $clave ) {
+    $mensajes = cdb_eventos_get_mensajes();
+    if ( ! isset( $mensajes[ $clave ] ) ) {
+        return '';
+    }
+    $mensaje = $mensajes[ $clave ];
+    if ( empty( $mensaje['mostrar'] ) ) {
+        return '';
+    }
+    $tipo  = isset( $mensaje['tipo'] ) ? $mensaje['tipo'] : 'info';
+    $texto = cdb_eventos_get_mensaje_text( $clave );
+    $sec   = isset( $mensaje['secundario'] ) ? $mensaje['secundario'] : '';
+    $html  = '<div class="cdb-eventos-mensaje cdb-eventos-' . esc_attr( $tipo ) . '">';
+    $html .= wp_kses_post( $texto );
+    if ( $sec ) {
+        $html .= ' <span class="mensaje-secundario">' . wp_kses_post( $sec ) . '</span>';
+    }
+    $html .= '</div>';
+    return $html;
+}
+
+function cdb_eventos_get_mensaje_js( $clave ) {
+    return esc_js( cdb_eventos_get_mensaje_text( $clave ) );
+}

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -1,0 +1,31 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+function cdb_eventos_enqueue_scripts() {
+    wp_enqueue_style( 'cdb-eventos', CDB_EVENTOS_URL . 'assets/cdb-eventos.css', array(), '1.0' );
+    wp_enqueue_style( 'cdb-eventos-config-mensajes', CDB_EVENTOS_URL . 'assets/css/config-mensajes.css', array(), '1.0' );
+    $tipos = cdb_eventos_get_tipos_color();
+    $css = '';
+    foreach ( $tipos as $slug => $tipo ) {
+        $bg = isset( $tipo['color'] ) ? $tipo['color'] : '#fff';
+        $color = isset( $tipo['color_texto'] ) ? $tipo['color_texto'] : '#000';
+        $css .= '.cdb-eventos-mensaje.cdb-eventos-' . esc_attr( $slug ) . '{background:' . esc_attr( $bg ) . ';color:' . esc_attr( $color ) . ';}';
+    }
+    if ( $css ) {
+        wp_add_inline_style( 'cdb-eventos-config-mensajes', $css );
+    }
+    wp_enqueue_script( 'cdb-eventos-mensajes', CDB_EVENTOS_URL . 'assets/js/mensajes.js', array(), '1.0', true );
+    wp_localize_script( 'cdb-eventos-mensajes', 'cdb_eventos_mensajes', cdb_eventos_get_mensajes_for_js() );
+}
+add_action( 'wp_enqueue_scripts', 'cdb_eventos_enqueue_scripts' );
+
+function cdb_eventos_get_mensajes_for_js() {
+    $mensajes = cdb_eventos_get_mensajes();
+    $out = array();
+    foreach ( $mensajes as $clave => $mensaje ) {
+        $out[ $clave ] = $mensaje['texto'];
+    }
+    return $out;
+}

--- a/includes/visibilidad.php
+++ b/includes/visibilidad.php
@@ -56,7 +56,7 @@ function cdb_eventos_lista_shortcode( $atts ) {
                     $now = new DateTime( 'now', wp_timezone() );
                     $interval = $now->diff( $evento_datetime );
                     if ( $interval->invert ) {
-                        $countdown_text = '<p class="countdown">El evento ya ha finalizado.</p>';
+                        $countdown_text = '<p class="countdown">' . esc_html( cdb_eventos_get_mensaje_text( 'evento_finalizado' ) ) . '</p>';
                     } else {
                         $days  = $interval->days;
                         $hours = $interval->h;
@@ -93,7 +93,7 @@ function cdb_eventos_lista_shortcode( $atts ) {
         }
         echo '</div>';
     } else {
-        echo '<p>No hay eventos disponibles.</p>';
+        echo cdb_eventos_get_mensaje( 'sin_eventos' );
     }
     wp_reset_postdata();
 
@@ -166,7 +166,7 @@ function cdb_eventos_lista_block_render( $attributes ) {
         }
         echo '</div>';
     } else {
-        echo '<p>No hay eventos disponibles.</p>';
+        echo cdb_eventos_get_mensaje( 'sin_eventos' );
     }
     wp_reset_postdata();
 


### PR DESCRIPTION
## Summary
- add default event messages and color types helpers
- provide admin screen to customize messages and notice styles
- enqueue dynamic notice styles and expose messages for front‑end use

## Testing
- `php -l cdb-eventos.php`
- `php -l includes/messages.php`
- `php -l includes/config-mensajes.php`
- `php -l includes/scripts.php`
- `php -l includes/inscripciones.php`
- `php -l includes/visibilidad.php`


------
https://chatgpt.com/codex/tasks/task_e_6893e5686d70832793d94cf37982262d