### PR TITLE
Add text domain to plugin header

### DIFF
--- a/cdb-eventos.php
+++ b/cdb-eventos.php
@@ -5,6 +5,7 @@
  * Version: 1.0.0
  * Author: CdB_
  * License: GPL2
+ * Text Domain: cdb-eventos
  */
 
 // Evitar acceso directo


### PR DESCRIPTION
## Summary
- include `Text Domain: cdb-eventos` in plugin header for translation metadata

## Testing
- `php -l cdb-eventos.php`


------
https://chatgpt.com/codex/tasks/task_e_6893ebaa331c8327ad49014feb1f72b3