### PR TITLE
Check array indices in message types loop

### DIFF
--- a/includes/config-mensajes.php
+++ b/includes/config-mensajes.php
@@ -56,6 +56,9 @@ function cdb_eventos_mensajes_admin_page() {
             $ctexto = isset( $_POST['tipos']['color_texto'] ) ? (array) $_POST['tipos']['color_texto'] : array();
             $count  = max( count( $slugs ), count( $nombres ) );
             for ( $i = 0; $i < $count; $i++ ) {
+                if ( ! isset( $slugs[ $i ], $nombres[ $i ], $clases[ $i ], $colores[ $i ], $ctexto[ $i ] ) ) {
+                    continue;
+                }
                 $slug = sanitize_key( $slugs[ $i ] );
                 if ( empty( $slug ) ) {
                     continue;


### PR DESCRIPTION
## Summary
- prevent undefined index notices in message type saving by checking all array indices before usage

## Testing
- `php -l includes/config-mensajes.php`


------
https://chatgpt.com/codex/tasks/task_e_689465ae0e408327a515b15011a5ef78