### PR TITLE
Delimit user ID in event subscription lookup

### DIFF
--- a/includes/usuario-suscripciones.php
+++ b/includes/usuario-suscripciones.php
@@ -52,7 +52,7 @@ function cdb_eventos_inscritos_shortcode( $atts ) {
         'meta_query'     => array(
             array(
                 'key'     => '_cdb_eventos_inscripciones',
-                'value'   => $user_id,
+                'value'   => '"' . $user_id . '"',
                 'compare' => 'LIKE'
             )
         )


### PR DESCRIPTION
## Summary
- Ensure user meta query wraps the user ID in quotes for precise matches

## Testing
- `php -l includes/usuario-suscripciones.php`


------
https://chatgpt.com/codex/tasks/task_e_689467a6fae48327901c2ac5cbf5957c