### PR TITLE
Agregar mensaje configurable para usuarios sin eventos

### DIFF
--- a/includes/messages.php
+++ b/includes/messages.php
@@ -47,6 +47,12 @@ function cdb_eventos_get_mensajes_default() {
             'tipo'      => 'info',
             'mostrar'   => true,
         ),
+        'sin_eventos_usuario' => array(
+            'texto'     => __( 'No estás inscrito en ningún evento.', 'cdb-eventos' ),
+            'secundario'=> '',
+            'tipo'      => 'info',
+            'mostrar'   => true,
+        ),
     );
 }
 

--- a/includes/usuario-suscripciones.php
+++ b/includes/usuario-suscripciones.php
@@ -60,7 +60,7 @@ function cdb_eventos_inscritos_shortcode( $atts ) {
     $query = new WP_Query( $args );
 
     if ( ! $query->have_posts() ) {
-        return wp_kses_post( $mensaje_accion ) . '<p>' . esc_html__( 'No estás inscrito en ningún evento.', 'cdb-eventos' ) . '</p>';
+        return wp_kses_post( $mensaje_accion ) . cdb_eventos_get_mensaje( 'sin_eventos_usuario' );
     }
 
     // 3) Mostrar el listado y el botón para eliminar la inscripción


### PR DESCRIPTION
## Summary
- Add `sin_eventos_usuario` default message so that users without subscriptions can see a configurable notice
- Use the new `sin_eventos_usuario` message in the subscriptions shortcode when no events are found

## Testing
- `php -l includes/messages.php`
- `php -l includes/usuario-suscripciones.php`


------
https://chatgpt.com/codex/tasks/task_e_6894fe5884b48327bb8da250420a8ed3