### PR TITLE
Unify aviso markup and styling with configurable borders

### DIFF
--- a/assets/css/config-mensajes.css
+++ b/assets/css/config-mensajes.css
@@ -1,28 +1,5 @@
-.cdb-eventos-mensaje {
-    padding: 10px 15px;
-    margin: 15px 0;
-    border-left: 4px solid transparent;
-}
-.cdb-eventos-mensaje.cdb-eventos-info {
-    background: #e5f5fa;
-    border-color: #46bfe2;
-    color: #0a4b78;
-}
-.cdb-eventos-mensaje.cdb-eventos-exito {
-    background: #e7f8ec;
-    border-color: #46b450;
-    color: #1e5220;
-}
-.cdb-eventos-mensaje.cdb-eventos-aviso {
-    background: #fff8e5;
-    border-color: #ffb900;
-    color: #604400;
-}
-.cdb-eventos-mensaje.cdb-eventos-error {
-    background: #fbeaea;
-    border-color: #dc3232;
-    color: #760000;
-}
-#cdb-eventos-tipos .form-table td input[type="text"] {
-    width: 100%;
-}
+.cdb-aviso{ padding:10px 15px; margin:15px 0; }
+.cdb-mensaje-destacado{ font-weight:700; display:block; }
+.cdb-mensaje-secundario{ display:block; font-size:.9em; }
+#cdb-eventos-tipos .form-table td input[type="text"]{ width:100%; }
+.cdb-preview-cell .cdb-aviso{ margin:0; }

--- a/assets/js/config-mensajes.js
+++ b/assets/js/config-mensajes.js
@@ -1,21 +1,76 @@
 jQuery(document).ready(function($){
-    if (typeof $.fn.wpColorPicker !== 'undefined') {
-        $('.cdb-color-field').wpColorPicker();
+    function hexToRgb(hex){
+        hex = hex.replace('#','');
+        if(hex.length === 3){
+            hex = hex.split('').map(function(h){return h+h;}).join('');
+        }
+        var num = parseInt(hex,16);
+        return {r:(num>>16)&255,g:(num>>8)&255,b:num&255};
     }
+    function luminance(r,g,b){
+        var a=[r,g,b].map(function(v){
+            v/=255;
+            return v<=0.03928 ? v/12.92 : Math.pow((v+0.055)/1.055,2.4);
+        });
+        return a[0]*0.2126 + a[1]*0.7152 + a[2]*0.0722;
+    }
+    function contrast(c1,c2){
+        var rgb1=hexToRgb(c1), rgb2=hexToRgb(c2);
+        var L1=luminance(rgb1.r,rgb1.g,rgb1.b)+0.05;
+        var L2=luminance(rgb2.r,rgb2.g,rgb2.b)+0.05;
+        return L1>L2?L1/L2:L2/L1;
+    }
+    function setupRow(row){
+        function update(){
+            var bg = row.find('input[name="tipos[bg][]"]').val() || '#ffffff';
+            var text = row.find('input[name="tipos[text][]"]').val() || '#000000';
+            var bcolor = row.find('input[name="tipos[border_color][]"]').val() || bg;
+            var bwidth = row.find('input[name="tipos[border_width][]"]').val() || '0px';
+            var bradius = row.find('input[name="tipos[border_radius][]"]').val() || '0px';
+            var preview = row.find('.cdb-aviso-preview');
+            preview.css({
+                'background-color': bg,
+                'color': text,
+                'border': bwidth + ' solid ' + bcolor,
+                'border-radius': bradius
+            });
+            if (bwidth === '0px' || bwidth === '0') {
+                preview.css('border-left', '4px solid ' + bcolor);
+            } else {
+                preview.css('border-left', '');
+            }
+            var warn = row.find('.cdb-contraste-aviso');
+            if (contrast(bg, text) < 4.5) {
+                warn.show();
+            } else {
+                warn.hide();
+            }
+        }
+        row.on('input change', 'input', update);
+        update();
+    }
+    if (typeof $.fn.wpColorPicker !== 'undefined') {
+        $('.cdb-color-field').wpColorPicker({ change: function(e){ $(e.target).trigger('input'); } });
+    }
+    $('#cdb-eventos-tipos tbody tr').each(function(){ setupRow($(this)); });
     $('#cdb-eventos-add-tipo').on('click', function(e){
         e.preventDefault();
         var table = $('#cdb-eventos-tipos').find('tbody');
-        var index = table.find('tr').length;
         var row = '<tr>'+
             '<td><input type="text" name="tipos[slug][]" value="" /></td>'+
-            '<td><input type="text" name="tipos[nombre][]" value="" /></td>'+
-            '<td><input type="text" name="tipos[clase][]" value="" /></td>'+
-            '<td><input type="text" class="cdb-color-field" name="tipos[color][]" value="" /></td>'+
-            '<td><input type="text" class="cdb-color-field" name="tipos[color_texto][]" value="" /></td>'+
+            '<td><input type="text" name="tipos[name][]" value="" /></td>'+
+            '<td><input type="text" name="tipos[class][]" value="" /></td>'+
+            '<td><input type="text" class="cdb-color-field" name="tipos[bg][]" value="" /></td>'+
+            '<td><input type="text" class="cdb-color-field" name="tipos[text][]" value="" /></td>'+
+            '<td><input type="text" class="cdb-color-field" name="tipos[border_color][]" value="" /></td>'+
+            '<td><input type="text" name="tipos[border_width][]" value="0px" class="small-text" /></td>'+
+            '<td><input type="text" name="tipos[border_radius][]" value="4px" class="small-text" /></td>'+
+            '<td class="cdb-preview-cell"><div class="cdb-aviso cdb-aviso-preview"><strong class="cdb-mensaje-destacado">Texto</strong></div><small class="cdb-contraste-aviso" style="display:none;color:#a00;">Contraste bajo</small></td>'+
             '</tr>';
         table.append(row);
         if (typeof $.fn.wpColorPicker !== 'undefined') {
-            table.find('.cdb-color-field').wpColorPicker();
+            table.find('.cdb-color-field').wpColorPicker({ change: function(e){ $(e.target).trigger('input'); } });
         }
+        setupRow(table.find('tr').last());
     });
 });

--- a/includes/config-mensajes.php
+++ b/includes/config-mensajes.php
@@ -49,25 +49,33 @@ function cdb_eventos_mensajes_admin_page() {
 
         $tipos = array();
         if ( isset( $_POST['tipos'] ) && is_array( $_POST['tipos'] ) ) {
-            $slugs  = isset( $_POST['tipos']['slug'] ) ? (array) $_POST['tipos']['slug'] : array();
-            $nombres= isset( $_POST['tipos']['nombre'] ) ? (array) $_POST['tipos']['nombre'] : array();
-            $clases = isset( $_POST['tipos']['clase'] ) ? (array) $_POST['tipos']['clase'] : array();
-            $colores= isset( $_POST['tipos']['color'] ) ? (array) $_POST['tipos']['color'] : array();
-            $ctexto = isset( $_POST['tipos']['color_texto'] ) ? (array) $_POST['tipos']['color_texto'] : array();
-            $count  = max( count( $slugs ), count( $nombres ) );
+            $slugs   = isset( $_POST['tipos']['slug'] ) ? (array) $_POST['tipos']['slug'] : array();
+            $nombres = isset( $_POST['tipos']['name'] ) ? (array) $_POST['tipos']['name'] : array();
+            $clases  = isset( $_POST['tipos']['class'] ) ? (array) $_POST['tipos']['class'] : array();
+            $bg      = isset( $_POST['tipos']['bg'] ) ? (array) $_POST['tipos']['bg'] : array();
+            $text    = isset( $_POST['tipos']['text'] ) ? (array) $_POST['tipos']['text'] : array();
+            $bcolor  = isset( $_POST['tipos']['border_color'] ) ? (array) $_POST['tipos']['border_color'] : array();
+            $bwidth  = isset( $_POST['tipos']['border_width'] ) ? (array) $_POST['tipos']['border_width'] : array();
+            $bradius = isset( $_POST['tipos']['border_radius'] ) ? (array) $_POST['tipos']['border_radius'] : array();
+            $count   = max( count( $slugs ), count( $nombres ) );
             for ( $i = 0; $i < $count; $i++ ) {
-                if ( ! isset( $slugs[ $i ], $nombres[ $i ], $clases[ $i ], $colores[ $i ], $ctexto[ $i ] ) ) {
+                if ( ! isset( $slugs[ $i ], $nombres[ $i ], $clases[ $i ], $bg[ $i ], $text[ $i ], $bcolor[ $i ], $bwidth[ $i ], $bradius[ $i ] ) ) {
                     continue;
                 }
                 $slug = sanitize_key( $slugs[ $i ] );
                 if ( empty( $slug ) ) {
                     continue;
                 }
+                $bw = trim( $bwidth[ $i ] );
+                $br = trim( $bradius[ $i ] );
                 $tipos[ $slug ] = array(
-                    'nombre'      => sanitize_text_field( $nombres[ $i ] ),
-                    'clase'       => sanitize_html_class( $clases[ $i ] ),
-                    'color'       => sanitize_hex_color( $colores[ $i ] ),
-                    'color_texto' => sanitize_hex_color( $ctexto[ $i ] ),
+                    'name'         => sanitize_text_field( $nombres[ $i ] ),
+                    'class'        => sanitize_html_class( $clases[ $i ] ),
+                    'bg'           => sanitize_hex_color( $bg[ $i ] ),
+                    'text'         => sanitize_hex_color( $text[ $i ] ),
+                    'border_color' => sanitize_hex_color( $bcolor[ $i ] ),
+                    'border_width' => ( is_numeric( $bw ) ? absint( $bw ) . 'px' : sanitize_text_field( $bw ) ),
+                    'border_radius'=> ( is_numeric( $br ) ? absint( $br ) . 'px' : sanitize_text_field( $br ) ),
                 );
             }
         }
@@ -112,16 +120,24 @@ function cdb_eventos_mensajes_admin_page() {
                         <th><?php esc_html_e( 'Clase', 'cdb-eventos' ); ?></th>
                         <th><?php esc_html_e( 'Color', 'cdb-eventos' ); ?></th>
                         <th><?php esc_html_e( 'Color del texto', 'cdb-eventos' ); ?></th>
+                        <th><?php esc_html_e( 'Color del borde', 'cdb-eventos' ); ?></th>
+                        <th><?php esc_html_e( 'Grosor', 'cdb-eventos' ); ?></th>
+                        <th><?php esc_html_e( 'Radio', 'cdb-eventos' ); ?></th>
+                        <th><?php esc_html_e( 'Previsualización', 'cdb-eventos' ); ?></th>
                     </tr>
                 </thead>
                 <tbody>
                 <?php foreach ( $tipos as $slug => $tipo ) : ?>
                     <tr>
                         <td><input type="text" name="tipos[slug][]" value="<?php echo esc_attr( $slug ); ?>" /></td>
-                        <td><input type="text" name="tipos[nombre][]" value="<?php echo esc_attr( $tipo['nombre'] ); ?>" /></td>
-                        <td><input type="text" name="tipos[clase][]" value="<?php echo esc_attr( $tipo['clase'] ); ?>" /></td>
-                        <td><input type="text" class="cdb-color-field" name="tipos[color][]" value="<?php echo esc_attr( $tipo['color'] ); ?>" /></td>
-                        <td><input type="text" class="cdb-color-field" name="tipos[color_texto][]" value="<?php echo esc_attr( $tipo['color_texto'] ); ?>" /></td>
+                        <td><input type="text" name="tipos[name][]" value="<?php echo esc_attr( $tipo['name'] ); ?>" /></td>
+                        <td><input type="text" name="tipos[class][]" value="<?php echo esc_attr( $tipo['class'] ); ?>" /></td>
+                        <td><input type="text" class="cdb-color-field" name="tipos[bg][]" value="<?php echo esc_attr( $tipo['bg'] ); ?>" /></td>
+                        <td><input type="text" class="cdb-color-field" name="tipos[text][]" value="<?php echo esc_attr( $tipo['text'] ); ?>" /></td>
+                        <td><input type="text" class="cdb-color-field" name="tipos[border_color][]" value="<?php echo esc_attr( $tipo['border_color'] ); ?>" /></td>
+                        <td><input type="text" name="tipos[border_width][]" value="<?php echo esc_attr( $tipo['border_width'] ); ?>" class="small-text" /></td>
+                        <td><input type="text" name="tipos[border_radius][]" value="<?php echo esc_attr( $tipo['border_radius'] ); ?>" class="small-text" /></td>
+                        <td class="cdb-preview-cell"><div class="cdb-aviso cdb-aviso-preview"><strong class="cdb-mensaje-destacado"><?php esc_html_e( 'Texto', 'cdb-eventos' ); ?></strong></div><small class="cdb-contraste-aviso" style="display:none;color:#a00;"><?php esc_html_e( 'Contraste bajo', 'cdb-eventos' ); ?></small></td>
                     </tr>
                 <?php endforeach; ?>
                 </tbody>

--- a/includes/inscripciones.php
+++ b/includes/inscripciones.php
@@ -78,7 +78,7 @@ add_action( 'add_meta_boxes', 'cdb_eventos_inscripciones_meta_box' );
 function cdb_eventos_inscripciones_meta_box_callback( $post ) {
     $inscripciones = get_post_meta( $post->ID, '_cdb_eventos_inscripciones', true );
     if ( ! is_array( $inscripciones ) || empty( $inscripciones ) ) {
-        echo '<p>' . esc_html( cdb_eventos_get_mensaje_text( 'sin_inscripciones' ) ) . '</p>';
+        echo wp_kses_post( cdb_eventos_get_mensaje( 'sin_inscripciones' ) );
         return;
     }
     echo '<ul>';

--- a/includes/messages.php
+++ b/includes/messages.php
@@ -53,6 +53,12 @@ function cdb_eventos_get_mensajes_default() {
             'tipo'      => 'info',
             'mostrar'   => true,
         ),
+        'login_eventos_usuario' => array(
+            'texto'     => __( 'Debes iniciar sesión para ver tus eventos inscritos.', 'cdb-eventos' ),
+            'secundario'=> '',
+            'tipo'      => 'aviso',
+            'mostrar'   => true,
+        ),
     );
 }
 
@@ -65,28 +71,40 @@ function cdb_eventos_get_mensajes() {
 function cdb_eventos_get_tipos_color_default() {
     return array(
         'info' => array(
-            'nombre'      => __( 'Información', 'cdb-eventos' ),
-            'clase'       => 'info',
-            'color'       => '#46bfe2',
-            'color_texto' => '#0a4b78',
+            'name'         => __( 'Información', 'cdb-eventos' ),
+            'class'        => 'cdb-aviso--info',
+            'bg'           => '#46bfe2',
+            'text'         => '#0a4b78',
+            'border_color' => '#46bfe2',
+            'border_width' => '0px',
+            'border_radius'=> '4px',
         ),
         'exito' => array(
-            'nombre'      => __( 'Éxito', 'cdb-eventos' ),
-            'clase'       => 'exito',
-            'color'       => '#46b450',
-            'color_texto' => '#1e5220',
+            'name'         => __( 'Éxito', 'cdb-eventos' ),
+            'class'        => 'cdb-aviso--exito',
+            'bg'           => '#46b450',
+            'text'         => '#1e5220',
+            'border_color' => '#46b450',
+            'border_width' => '0px',
+            'border_radius'=> '4px',
         ),
         'aviso' => array(
-            'nombre'      => __( 'Aviso', 'cdb-eventos' ),
-            'clase'       => 'aviso',
-            'color'       => '#ffb900',
-            'color_texto' => '#604400',
+            'name'         => __( 'Aviso', 'cdb-eventos' ),
+            'class'        => 'cdb-aviso--aviso',
+            'bg'           => '#ffb900',
+            'text'         => '#604400',
+            'border_color' => '#ffb900',
+            'border_width' => '0px',
+            'border_radius'=> '4px',
         ),
         'error' => array(
-            'nombre'      => __( 'Error', 'cdb-eventos' ),
-            'clase'       => 'error',
-            'color'       => '#dc3232',
-            'color_texto' => '#760000',
+            'name'         => __( 'Error', 'cdb-eventos' ),
+            'class'        => 'cdb-aviso--error',
+            'bg'           => '#dc3232',
+            'text'         => '#760000',
+            'border_color' => '#dc3232',
+            'border_width' => '0px',
+            'border_radius'=> '4px',
         ),
     );
 }
@@ -94,7 +112,36 @@ function cdb_eventos_get_tipos_color_default() {
 function cdb_eventos_get_tipos_color() {
     $defaults = cdb_eventos_get_tipos_color_default();
     $saved    = get_option( 'cdb_eventos_tipos_color', array() );
-    return wp_parse_args( $saved, $defaults );
+    $tipos    = wp_parse_args( $saved, $defaults );
+    foreach ( $tipos as $slug => $tipo ) {
+        $base = isset( $defaults[ $slug ] ) ? $defaults[ $slug ] : array();
+        $tipo = wp_parse_args( $tipo, $base );
+
+        // Migración perezosa desde claves antiguas
+        if ( isset( $tipo['nombre'] ) && ! isset( $tipo['name'] ) ) {
+            $tipo['name'] = $tipo['nombre'];
+        }
+        if ( isset( $tipo['clase'] ) && ! isset( $tipo['class'] ) ) {
+            $tipo['class'] = 'cdb-aviso--' . $tipo['clase'];
+        }
+        if ( isset( $tipo['color'] ) && ! isset( $tipo['bg'] ) ) {
+            $tipo['bg'] = $tipo['color'];
+        }
+        if ( isset( $tipo['color_texto'] ) && ! isset( $tipo['text'] ) ) {
+            $tipo['text'] = $tipo['color_texto'];
+        }
+        if ( empty( $tipo['border_color'] ) ) {
+            $tipo['border_color'] = $tipo['bg'];
+        }
+        if ( empty( $tipo['border_width'] ) ) {
+            $tipo['border_width'] = '0px';
+        }
+        if ( empty( $tipo['border_radius'] ) ) {
+            $tipo['border_radius'] = '4px';
+        }
+        $tipos[ $slug ] = $tipo;
+    }
+    return $tipos;
 }
 
 function cdb_eventos_get_mensaje_text( $clave ) {
@@ -114,10 +161,11 @@ function cdb_eventos_get_mensaje( $clave ) {
     $tipo  = isset( $mensaje['tipo'] ) ? $mensaje['tipo'] : 'info';
     $texto = cdb_eventos_get_mensaje_text( $clave );
     $sec   = isset( $mensaje['secundario'] ) ? $mensaje['secundario'] : '';
-    $html  = '<div class="cdb-eventos-mensaje cdb-eventos-' . esc_attr( $tipo ) . '">';
-    $html .= wp_kses_post( $texto );
+    $clase = 'cdb-aviso cdb-aviso--' . esc_attr( $tipo ) . ' cdb-eventos-mensaje cdb-eventos-' . esc_attr( $tipo );
+    $html  = '<div class="' . $clase . '">';
+    $html .= '<strong class="cdb-mensaje-destacado">' . wp_kses_post( $texto ) . '</strong>';
     if ( $sec ) {
-        $html .= ' <span class="mensaje-secundario">' . wp_kses_post( $sec ) . '</span>';
+        $html .= '<span class="cdb-mensaje-secundario">' . wp_kses_post( $sec ) . '</span>';
     }
     $html .= '</div>';
     return $html;

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -9,9 +9,15 @@ function cdb_eventos_enqueue_scripts() {
     $tipos = cdb_eventos_get_tipos_color();
     $css = '';
     foreach ( $tipos as $slug => $tipo ) {
-        $bg = isset( $tipo['color'] ) ? $tipo['color'] : '#fff';
-        $color = isset( $tipo['color_texto'] ) ? $tipo['color_texto'] : '#000';
-        $css .= '.cdb-eventos-mensaje.cdb-eventos-' . esc_attr( $slug ) . '{background:' . esc_attr( $bg ) . ';color:' . esc_attr( $color ) . ';}';
+        $bg    = isset( $tipo['bg'] ) ? $tipo['bg'] : '#fff';
+        $color = isset( $tipo['text'] ) ? $tipo['text'] : '#000';
+        $bcolor = isset( $tipo['border_color'] ) ? $tipo['border_color'] : $bg;
+        $bwidth = isset( $tipo['border_width'] ) ? $tipo['border_width'] : '0px';
+        $bradius= isset( $tipo['border_radius'] ) ? $tipo['border_radius'] : '0px';
+        $css .= '.cdb-aviso.cdb-aviso--' . esc_attr( $slug ) . '{background-color:' . esc_attr( $bg ) . ';color:' . esc_attr( $color ) . ';border:' . esc_attr( $bwidth ) . ' solid ' . esc_attr( $bcolor ) . ';border-radius:' . esc_attr( $bradius ) . ';}';
+        if ( '0px' === $bwidth || '0' === $bwidth ) {
+            $css .= '.cdb-aviso.cdb-aviso--' . esc_attr( $slug ) . '{border-left:4px solid ' . esc_attr( $bcolor ) . ';}';
+        }
     }
     if ( $css ) {
         wp_add_inline_style( 'cdb-eventos-config-mensajes', $css );

--- a/includes/usuario-suscripciones.php
+++ b/includes/usuario-suscripciones.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function cdb_eventos_inscritos_shortcode( $atts ) {
     if ( ! is_user_logged_in() ) {
-        return '<p>' . esc_html__( 'Debes iniciar sesión para ver tus eventos inscritos.', 'cdb-eventos' ) . '</p>';
+        return cdb_eventos_get_mensaje( 'login_eventos_usuario' );
     }
 
     $user_id = get_current_user_id();


### PR DESCRIPTION
## Summary
- implement common `<div class="cdb-aviso">` markup including legacy classes
- add configurable border color, width and radius for message types with live preview and contrast check
- generate dynamic CSS for aviso types and update admin outputs to use new markup

## Testing
- `php -l includes/messages.php`
- `php -l includes/config-mensajes.php`
- `php -l includes/scripts.php`
- `php -l includes/inscripciones.php`
- `php -l includes/usuario-suscripciones.php`


------
https://chatgpt.com/codex/tasks/task_e_6895e1f0eb20832785a94cbd50c57132